### PR TITLE
Update eslint to fix linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
+  "extends": ["standard", "standard-react"],
   "parser": "babel-eslint",
-  "extends": "standard",
   "env": {
     "browser": true,
     "mocha": true

--- a/package.json
+++ b/package.json
@@ -45,9 +45,10 @@
   },
   "devDependencies": {
     "babel-eslint": "^3.1.15",
-    "eslint": "^0.22.1",
-    "eslint-config-standard": "^2.0.1",
-    "eslint-plugin-react": "^2.5.0",
+    "eslint": "^0.23.0",
+    "eslint-config-standard": "^3.2.0",
+    "eslint-config-standard-react": "^1.0.0",
+    "eslint-plugin-react": "^2.5.2",
     "expect.js": "^0.3.1",
     "isparta-instrumenter-loader": "^0.2.1",
     "karma": "^0.12.36",


### PR DESCRIPTION
eslint-config-standard split off the react config into a new package
added the new eslint-config-standard-react package
enabled this package in the eslint config
updated eslint which now allows extends to be an array
