### PR TITLE
Fix reference to react-transform-hmr docs

### DIFF
--- a/webpack.make.js
+++ b/webpack.make.js
@@ -147,7 +147,7 @@ module.exports = function makeWebpackConfig (options) {
       transforms: [{
 
         // Enable automatic hot reload of react components
-        // Reference: https://github.com/gaearon/react-transform-catch-errors
+        // Reference: https://github.com/gaearon/react-transform-hmr
         transform: 'react-transform-hmr',
         imports: ['react'],
         locals: ['module']


### PR DESCRIPTION
Fix the reference to the react-transform-hmr docs in the webpack.make.js. Was erroneously linking to react-transform-catch-errors docs instead.
