### PR TITLE
Remove unused dependency from app entrypoint

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -6,7 +6,6 @@ import 'normalize.css'
 import styles from './styles.css'
 
 import debug from 'debug'
-import React from 'react'
 import ReactDOM from 'react-dom'
 import Hello from './components/Hello'
 


### PR DESCRIPTION
The `import React from 'react'` statement is no longer needed after you upgraded to React 0.14
