### PR TITLE
Fix path issue on windows, when mix "/" and "\" with css-loader

### DIFF
--- a/webpack.make.js
+++ b/webpack.make.js
@@ -1,9 +1,9 @@
 // Modules
-var webpack = require('webpack');
-var autoprefixer = require('autoprefixer');
-var HtmlWebpackPlugin = require('html-webpack-plugin');
-var ExtractTextPlugin = require('extract-text-webpack-plugin');
-var path = require('path');
+var webpack = require('webpack')
+var autoprefixer = require('autoprefixer')
+var HtmlWebpackPlugin = require('html-webpack-plugin')
+var ExtractTextPlugin = require('extract-text-webpack-plugin')
+var path = require('path')
 
 /**
  * Make webpack config

--- a/webpack.make.js
+++ b/webpack.make.js
@@ -1,8 +1,9 @@
 // Modules
-var webpack = require('webpack')
-var autoprefixer = require('autoprefixer')
-var HtmlWebpackPlugin = require('html-webpack-plugin')
-var ExtractTextPlugin = require('extract-text-webpack-plugin')
+var webpack = require('webpack');
+var autoprefixer = require('autoprefixer');
+var HtmlWebpackPlugin = require('html-webpack-plugin');
+var ExtractTextPlugin = require('extract-text-webpack-plugin');
+var path = require('path');
 
 /**
  * Make webpack config
@@ -57,7 +58,7 @@ module.exports = function makeWebpackConfig (options) {
   } else {
     config.output = {
       // Absolute output directory
-      path: __dirname + '/public',
+      path: path.join(__dirname, 'public'),
 
       // Output path from the view of the page
       // Uses webpack-dev-server in development
@@ -177,7 +178,7 @@ module.exports = function makeWebpackConfig (options) {
   // Allow loading css through js and getting the className
   var localCssLoader = {
     test: /\.css$/,
-    include: __dirname + '/app',
+    include: path.join(__dirname, 'app'),
     // Reference: https://github.com/webpack/extract-text-webpack-plugin
     // Extract css files in production builds
     loader: ExtractTextPlugin.extract(
@@ -195,7 +196,7 @@ module.exports = function makeWebpackConfig (options) {
   // The same as localCssLoader, but imports are globals
   var globalCssLoader = {
     test: /\.css$/,
-    include: __dirname + '/node_modules',
+    include: path.join(__dirname, 'node_modules'),
     loader: ExtractTextPlugin.extract('style', 'css?sourceMap!postcss')
   }
 


### PR DESCRIPTION
__dirname + "/app" won't work well on windows when deal with css-loader, may be css-loader issue. use path.join to let the path friendly on window. It should also work on Mac or linux.

Some related error from windows

ERROR in ./app/styles.css
Module parse failed: D:\tests\react-web-app\app\styles.css Line 1: Unexpected token :
You may need an appropriate loader to handle this file type.
| :global *,
| :global *:after,
| :global *:before {
 @ ./app/index.js 11:17-40

ERROR in ./~/normalize.css/normalize.css
Module parse failed: D:\tests\react-web-app\node_modules\normalize.css\normalize.css Line 9: Unexpected token {
You may need an appropriate loader to handle this file type.
|  _/
|
| html {
|   font-family: sans-serif; /_ 1 _/
|   -ms-text-size-adjust: 100%; /_ 2 */
 @ ./app/index.js 9:0-24

ERROR in ./app/components/Hello/Hello.css
Module parse failed: D:\tests\react-web-app\app\components\Hello\Hello.css Line 1: Unexpected token .
You may need an appropriate loader to handle this file type.
| .greeting {
|   color: #00F;
| }
 @ ./app/components/Hello/Hello.js 29:16-38
