### PR TITLE
Address redbox-react package version issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "react-addons-test-utils": "^0.14.0",
     "react-transform-catch-errors": "^1.0.0",
     "react-transform-hmr": "^1.0.1",
-    "redbox-react": "^1.1.1",
+    "redbox-react": "1.1.1",
     "standard": "^5.3.1",
     "style-loader": "^0.12.4",
     "webpack": "^1.12.2",


### PR DESCRIPTION
After cloning the repo, installing dependencies, starting a server and opening the app in the browser one gets the following error in the browser console:

```
Uncaught Error: imports[1] for react-transform-catch-errors does not look like a React component.
```

In addition, this prevents the `Hello` component from rendering.

In this case `react-transform-catch-errors` uses `redbox-react` to render error messages but fails to do this due to incompatibilities between the two packages, since the former is already deprecated and hasn't been maintained for almost 2 years. This PR changes the [caret range version specification](https://docs.npmjs.com/misc/semver#caret-ranges-123-025-004) to the exact version of `redbox-react` to fix the error.

Resolves https://github.com/cesarandreu/web-app/issues/21.

/cc @cesarandreu 